### PR TITLE
fix: refresh CV content for 2026

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -90,7 +90,7 @@
 \section{Soft Skills}
 \cvitem{Design}{Generalist across the delivery lifecycle, deep understanding of complex distributed systems.}
 \cvitem{Analysis}{Exceptional at problem solving and debugging.}
-\cvitem{Assessment}{Seasoned interviewer for student intake and engineering hires, reading past surface fluency.}
+\cvitem{Assessment}{Rigorous technical interviewing, reading past surface fluency.}
 \cvitem{Discipline}{Skilled in team leadership, time management, and goal setting.}
 
 \section{Languages}

--- a/main.tex
+++ b/main.tex
@@ -51,7 +51,7 @@
 \item Lead an agile, self-organizing remote team of 5 to 10+ mentors.
 \item Own team capacity planning against shifting demand, including restructuring, exit negotiations and backfills.
 \item Drove company-wide Claude adoption together with the CTO as the internal go-to for enablement, and piloted AI-assisted curriculum development.
-\item Led an 8-week fullstack course for a B2B client fully in English, with onsite hands-on days in Oslo.
+\item Lead B2B-facing educational courses, most recently an 8-week fullstack engagement for a client in Oslo, delivered remotely and onsite.
 \end{itemize}}
 \cventry{2025}{AI Customer Support Automation}{Side project}{remote}{}{Vertex AI (Gemini Pro) and n8n integrated with a bespoke PHP webshop; 80\% of drafted replies correct in evaluation at 1000+ multi-country enquiries monthly.}
 \cventry{2016--2022}{Software Developer Mentor}{Codecool Kft.}{\underline{Miskolc} (onsite/remote)}{}{

--- a/main.tex
+++ b/main.tex
@@ -42,7 +42,7 @@
 
 \begin{document}
 \makecvtitle
-\vspace{-2\baselineskip}
+\vspace{-2.5\baselineskip}
 
 \section{Experience}
 \cventry{2022--}{Team Lead and Software Developer Mentor}{Codecool Kft.}{\underline{Budapest} (remote/hybrid)}{}{
@@ -61,20 +61,15 @@
 \end{itemize}}
 \cventry{2015--2016}{Software Engineer}{MetaPack Ltd.}{\underline{London} (onsite)}{}{
 \begin{itemize}
-\item Collaborated in the design and drove the implementation of an internal support automation tool.
-\item Deployed automated browser-based end-to-end tests using containerization.
-\item Improved the efficiency of continuous integration pipelines by introducing fail-fast diagnostics.
+\item Drove implementation of an internal support automation tool, with containerized browser-based end-to-end tests and fail-fast CI diagnostics.
 \end{itemize}}
 \cventry{2013--2015}{Senior Application Developer}{Synergon Integrator Ltd.}{\underline{Miskolc} (onsite)}{}{
 \begin{itemize}
-\item Coordinated programmatic communication between smart metering devices and internal backends.
-\item Implemented custom user interface components and complex, long-running background services.
-\item Collaborated in a 10+ member, cross-location Scrum team successfully.
+\item Built smart metering device communication, custom UI components and long-running background services in a 10+ member, cross-location Scrum team.
 \end{itemize}}
 \cventry{2009--2013}{Application Developer}{Dolphio Consulting Ltd.}{\underline{Miskolc} (onsite)}{}{
 \begin{itemize}
-\item Created a queryable web-service for a speed trap notifier Android application.
-\item Took over operation of and improved a news crawler system in tight client collaboration.
+\item Built a queryable web service for an Android application and improved an inherited news crawler in tight client collaboration.
 \end{itemize}}
 
 \section{Publications}
@@ -85,14 +80,14 @@
 \cventry{2005--2009}{B.S. Computer Science}{University of Miskolc}{Miskolc}{}{Infocommunication specialization.}
 
 \section{Hard Skills}
-\cvitem{Programming}{Expert in Java, advanced with Python and JavaScript, prior commercial experience with C\#.}
-\cvitem{Frameworks}{Experienced with Spring, React and ASP.NET.}
-\cvitem{Automation}{Intimate with Git, Docker, Terraform, AWS/Azure, CI/CD via GitHub Actions, Maven and Gradle.}
+\cvitem{Programming}{Expert in Java, advanced with Python and JavaScript, prior commercial experience with C\#; Spring, React, ASP.NET.}
+\cvitem{Data}{Strong SQL: PostgreSQL in production, SQL Server at course level.}
+\cvitem{Platform}{Linux and remote server administration, Docker, infrastructure as code with Terraform, AWS/Azure, GitHub Actions, Maven and Gradle.}
 
 \section{Soft Skills}
-\cvitem{Breadth}{Generalist across the full delivery lifecycle, with pragmatic judgment of engineering trade-offs.}
-\cvitem{Design}{Deep understanding of complex distributed computer systems.}
+\cvitem{Design}{Generalist across the delivery lifecycle, deep understanding of complex distributed systems.}
 \cvitem{Analysis}{Exceptional at problem solving and debugging.}
+\cvitem{Assessment}{Seasoned interviewer for student intake and engineering hires, reading past surface fluency.}
 \cvitem{Discipline}{Skilled in team leadership, time management, and goal setting.}
 
 \section{Languages}

--- a/main.tex
+++ b/main.tex
@@ -47,7 +47,7 @@
 \section{Experience}
 \cventry{2022--}{Team Lead and Software Developer Mentor}{Codecool Kft.}{\underline{Budapest} (remote/hybrid)}{}{
 \begin{itemize}
-\item Envisioned and drove a structural redesign of the flagship education product, balancing falling intake, rising salaries and a contracting market; launching October 2026.
+\item Envisioned and drove a structural redesign of the flagship education product against shrinking intake and margins; launches October 2026.
 \item Lead an agile self-organizing team of 5 technology expert mentors, 10+ at peak, in a remote setting.
 \item Own team capacity planning against shifting business demand, including restructuring, exit negotiations and continuity after departures.
 \item Drove company-wide Claude adoption together with the CTO as the internal go-to for enablement, and piloted AI-assisted curriculum development.

--- a/main.tex
+++ b/main.tex
@@ -44,15 +44,16 @@
 \makecvtitle
 \vspace{-2\baselineskip}
 
-\section{Motto}
-\cvitem{}{I get the job done.}
-
 \section{Experience}
-\cventry{2022--}{Team Lead, Software Developer Mentor}{Codecool Kft.}{\underline{Budapest} (remote/hybrid)}{}{
+\cventry{2022--}{Team Lead and Software Developer Mentor}{Codecool Kft.}{\underline{Budapest} (remote/hybrid)}{}{
 \begin{itemize}
-\item Lead an agile self-organizing team of technology expert mentors in a remote setting.
-\item Oversaw complex resource allocation needs, scheduling, coordinate work between departments.
+\item Envisioned and drove a structural redesign of the flagship education product, balancing falling intake, rising salaries and a contracting market; launching October 2026.
+\item Lead an agile self-organizing team of 5 technology expert mentors, 10+ at peak, in a remote setting.
+\item Own team capacity planning against shifting business demand, including restructuring, exit negotiations and continuity after departures.
+\item Drove company-wide Claude adoption together with the CTO as the internal go-to for enablement, and piloted AI-assisted curriculum development.
+\item Led an 8-week fullstack course for a B2B client fully in English, with onsite hands-on days in Oslo.
 \end{itemize}}
+\cventry{2025}{AI Customer Support Automation}{Side project}{remote}{}{Vertex AI (Gemini Pro) and n8n integrated with a bespoke PHP webshop; 80\% of drafted replies correct in evaluation at 1000+ multi-country enquiries monthly.}
 \cventry{2016--2022}{Software Developer Mentor}{Codecool Kft.}{\underline{Miskolc} (onsite/remote)}{}{
 \begin{itemize}
 \item Guided the development and interview preparation successfully for 100+ junior developers.
@@ -66,7 +67,7 @@
 \end{itemize}}
 \cventry{2013--2015}{Senior Application Developer}{Synergon Integrator Ltd.}{\underline{Miskolc} (onsite)}{}{
 \begin{itemize}
-\item Coordinate programmatic communication between smart metering devices and internal backends.
+\item Coordinated programmatic communication between smart metering devices and internal backends.
 \item Implemented custom user interface components and complex, long-running background services.
 \item Collaborated in a 10+ member, cross-location Scrum team successfully.
 \end{itemize}}
@@ -76,24 +77,20 @@
 \item Took over operation of and improved a news crawler system in tight client collaboration.
 \end{itemize}}
 
-\section{Projects}
+\section{Publications}
 \cventry{Video Course}{\href{https://www.packtpub.com/en-us/product/design-patterns-and-solid-principles-with-java-9781838642235}{Design Patterns and SOLID Principles with Java}}{Packt Publishing}{}{}{}
-\cventry{Cloud/Mobile}{Cloud-based `Music Extractor' with \href{https://github.com/kohanyirobert/aws-lambda-sniff}{AWS Lambda} and \href{https://github.com/kohanyirobert/sniff-android}{Android}}{}{}{}{}
-\cventry{Sample Project}{\href{https://github.com/kohanyirobert/spring-boot-backend-sample}{Spring Boot} with \href{https://github.com/kohanyirobert/angular-frontend-sample}{Angular}}{}{}{}{}
-\cventry{Automation}{VirtualBox virtual machine image \href{https://github.com/kohanyirobert/vms}{build automation scripts with Python}}{}{}{}{}
-\cventry{Interview Test}{\href{https://github.com/kohanyirobert/bluebird-test}{Java Console App using JPA with Hibernate}}{}{}{}{}
-\cventry{Master's Thesis}{\href{https://github.com/kohanyirobert/ebson}{Extensible BSON Encoder/Decoder}}{University of Miskolc}{}{}{}
 
 \section{Education}
-\cventry{2009--2013}{M.S. Computer Science}{University of Miskolc}{Miskolc}{}{Software Development specialization.}
+\cventry{2009--2013}{M.S. Computer Science}{University of Miskolc}{Miskolc}{}{Software Development specialization. Thesis: \href{https://github.com/kohanyirobert/ebson}{Extensible BSON Encoder/Decoder}.}
 \cventry{2005--2009}{B.S. Computer Science}{University of Miskolc}{Miskolc}{}{Infocommunication specialization.}
 
 \section{Hard Skills}
-\cvitem{Programming}{Expert in Java and C\#, advanced with Python and JavaScript.}
-\cvitem{Frameworks}{Experienced with Spring, Java EE, Angular, React, ASP.NET.}
-\cvitem{Automation}{Intimate with Git, Docker, Terraform, AWS/Azure, CI/CD and build tools like Maven and Gradle.}
+\cvitem{Programming}{Expert in Java, advanced with Python and JavaScript, prior commercial experience with C\#.}
+\cvitem{Frameworks}{Experienced with Spring, React and ASP.NET.}
+\cvitem{Automation}{Intimate with Git, Docker, Terraform, AWS/Azure, CI/CD via GitHub Actions, Maven and Gradle.}
 
 \section{Soft Skills}
+\cvitem{Breadth}{Generalist across the full delivery lifecycle, with pragmatic judgment of engineering trade-offs.}
 \cvitem{Design}{Deep understanding of complex distributed computer systems.}
 \cvitem{Analysis}{Exceptional at problem solving and debugging.}
 \cvitem{Discipline}{Skilled in team leadership, time management, and goal setting.}

--- a/main.tex
+++ b/main.tex
@@ -53,7 +53,10 @@
 \item Drove company-wide Claude adoption together with the CTO as the internal go-to for enablement, and piloted AI-assisted curriculum development.
 \item Lead B2B-facing educational courses, most recently an 8-week fullstack engagement for a client in Oslo, delivered remotely and onsite.
 \end{itemize}}
-\cventry{2025}{AI Customer Support Automation}{Side project}{remote}{}{Vertex AI (Gemini Pro) and n8n integrated with a bespoke PHP webshop; 80\% of drafted replies correct in evaluation at 1000+ multi-country enquiries monthly.}
+\cventry{2025}{AI Customer Support Automation}{oem-parts.hu}{\underline{Budapest} (remote)}{}{
+\begin{itemize}
+\item Built AI customer support on Gemini with n8n; 80\% of drafted replies correct in evaluation at 1000+ monthly enquiries.
+\end{itemize}}
 \cventry{2016--2022}{Software Developer Mentor}{Codecool Kft.}{\underline{Miskolc} (onsite/remote)}{}{
 \begin{itemize}
 \item Guided the development and interview preparation successfully for 100+ junior developers.

--- a/main.tex
+++ b/main.tex
@@ -85,7 +85,7 @@
 \section{Hard Skills}
 \cvitem{Programming}{Polyglot: expert in Java and C\#, fluent in Python and JavaScript; Spring, React, ASP.NET.}
 \cvitem{Data}{Strong SQL with PostgreSQL and SQL Server; database and domain design.}
-\cvitem{Platform}{Linux and remote server administration, Docker, infrastructure as code with Terraform, AWS/Azure, GitHub Actions, Maven and Gradle.}
+\cvitem{Platform}{DevOps across Linux and Docker, infrastructure as code with Terraform, AWS/Azure and GitHub Actions.}
 
 \section{Soft Skills}
 \cvitem{Design}{Generalist across the delivery lifecycle, deep understanding of complex distributed systems.}

--- a/main.tex
+++ b/main.tex
@@ -83,7 +83,7 @@
 \cventry{2005--2009}{B.S. Computer Science}{University of Miskolc}{Miskolc}{}{Infocommunication specialization.}
 
 \section{Hard Skills}
-\cvitem{Programming}{Expert in Java, advanced with Python and JavaScript, prior commercial experience with C\#; Spring, React, ASP.NET.}
+\cvitem{Programming}{Polyglot: expert in Java and C\#, fluent in Python and JavaScript; Spring, React, ASP.NET.}
 \cvitem{Data}{Strong SQL: PostgreSQL in production, SQL Server at course level.}
 \cvitem{Platform}{Linux and remote server administration, Docker, infrastructure as code with Terraform, AWS/Azure, GitHub Actions, Maven and Gradle.}
 

--- a/main.tex
+++ b/main.tex
@@ -84,7 +84,7 @@
 
 \section{Hard Skills}
 \cvitem{Programming}{Polyglot: expert in Java and C\#, fluent in Python and JavaScript; Spring, React, ASP.NET.}
-\cvitem{Data}{Strong SQL: PostgreSQL in production, SQL Server at course level.}
+\cvitem{Data}{Strong SQL with PostgreSQL and SQL Server; database and domain design.}
 \cvitem{Platform}{Linux and remote server administration, Docker, infrastructure as code with Terraform, AWS/Azure, GitHub Actions, Maven and Gradle.}
 
 \section{Soft Skills}

--- a/main.tex
+++ b/main.tex
@@ -49,7 +49,7 @@
 \begin{itemize}
 \item Envisioned and drove a structural redesign of the flagship education product against shrinking intake and margins; launches October 2026.
 \item Lead an agile, self-organizing remote team of 5 to 10+ mentors.
-\item Own team capacity planning against shifting business demand, including restructuring, exit negotiations and continuity after departures.
+\item Own team capacity planning against shifting demand, including restructuring, exit negotiations and backfills.
 \item Drove company-wide Claude adoption together with the CTO as the internal go-to for enablement, and piloted AI-assisted curriculum development.
 \item Led an 8-week fullstack course for a B2B client fully in English, with onsite hands-on days in Oslo.
 \end{itemize}}

--- a/main.tex
+++ b/main.tex
@@ -48,7 +48,7 @@
 \cventry{2022--}{Team Lead and Software Developer Mentor}{Codecool Kft.}{\underline{Budapest} (remote/hybrid)}{}{
 \begin{itemize}
 \item Envisioned and drove a structural redesign of the flagship education product against shrinking intake and margins; launches October 2026.
-\item Lead an agile self-organizing team of 5 technology expert mentors, 10+ at peak, in a remote setting.
+\item Lead an agile, self-organizing remote team of 5 to 10+ mentors.
 \item Own team capacity planning against shifting business demand, including restructuring, exit negotiations and continuity after departures.
 \item Drove company-wide Claude adoption together with the CTO as the internal go-to for enablement, and piloted AI-assisted curriculum development.
 \item Led an 8-week fullstack course for a B2B client fully in English, with onsite hands-on days in Oslo.

--- a/main.tex
+++ b/main.tex
@@ -91,6 +91,7 @@
 \cvitem{Design}{Generalist across the delivery lifecycle, deep understanding of complex distributed systems.}
 \cvitem{Analysis}{Exceptional at problem solving and debugging.}
 \cvitem{Assessment}{Rigorous technical interviewing, reading past surface fluency.}
+\cvitem{Ownership}{Closes the gaps others walk past, in delivery and in knowledge, and brings the team along.}
 \cvitem{Discipline}{Skilled in team leadership, time management, and goal setting.}
 
 \section{Languages}

--- a/main.tex
+++ b/main.tex
@@ -96,6 +96,6 @@
 
 \section{Languages}
 \cvitemwithcomment{Hungarian}{Native.}{}
-\cvitemwithcomment{English}{Fluent.}{}
+\cvitemwithcomment{English}{Fluent (C1).}{}
 
 \end{document}


### PR DESCRIPTION
Refresh of `main.tex`; content had not changed substantively since 2025-05-24.

## Corrections

- Current job title was left as the residue of a pipeline test in eec877a (`Team Lead, ...` → `Team Lead and ...`).
- Present-tense `Coordinate` in the 2013–2015 Synergon role → `Coordinated`.
- Removed the ungrammatical `Oversaw ... coordinate work` bullet.

## Experience

Current role went from 2 bullets with no team size to 5: the flagship product redesign launching October 2026, team size as a range (5 to 10+), capacity planning including restructuring and exit negotiations, company-wide Claude adoption with the CTO, and recurring B2B course delivery with the Oslo engagement as the recent example.

Added a 2025 entry for the oem-parts.hu AI customer support work (Gemini + n8n, 80% of drafted replies correct in evaluation at 1000+ monthly enquiries).

Compressed the pre-2016 roles to one bullet each without dropping content, so weighting matches where the value is.

## Sections

- `Projects` → `Publications`, trimmed from 6 entries to Packt alone. Music Extractor dropped (no longer runs); the interview test, Spring/Angular samples and VirtualBox scripts dropped as early-career filler.
- Master’s thesis folded into the M.S. description with its link intact, at no cost in lines.
- `Motto` dropped to hold one page.

## Skills

- Hard Skills folded from 3 loose items to `Programming` / `Data` / `Platform`; added SQL (PostgreSQL, SQL Server), database and domain design, and DevOps/Linux. Jakarta EE and Angular removed as not defensible. Kubernetes deliberately omitted — hands-on exposure only.
- Soft Skills: added `Assessment` (technical interviewing) and `Ownership` (closing delivery and knowledge gaps); merged breadth into `Design`.
- `English` now notes C1.

## Verification

Built locally with Podman against `ghcr.io/kohanyirobert/cv:latest` — one page, no errors. `\vspace` after `\makecvtitle` tightened from `-2` to `-2.5\baselineskip` to hold the page; it is load-bearing, so the next addition will likely spill to a second page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYrrbD4tMv7PddnixE3GPi