### PR TITLE
fix: pin TeX Live and the base image (#68)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,13 +3,9 @@ name: Build
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - Dockerfile
   push:
     branches:
       - main
-    paths-ignore:
-      - Dockerfile
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-# The latest tag refers to LTS in case of Ubuntu.
-# Using it in hope that TeX live follows the release cadence.
-FROM ubuntu:latest
+# Pinned rather than :latest. Any change to this file rebuilds and republishes
+# the image, so an unpinned base would make every rebuild a silent OS upgrade.
+# 24.04 is what the currently published image was built from.
+FROM ubuntu:24.04
 # See *Locales* at https://hub.docker.com/_/ubuntu
 RUN apt-get update && apt-get install -y \
 # Curl required to download TeX Live installer.
   curl \
-# Needed for GitHub codespaces.
-  git \
 # Locales required to produce PDF with latexmk.
   locales \
 # Perl required to run (at least) the TeX Live installer.
@@ -15,20 +14,30 @@ RUN apt-get update && apt-get install -y \
 # Set the locale to UTF-8. Required for latexmk to work properly.
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG=en_US.utf8
-# This installs the *latest* TeX Live version - installing a specific version is not really supported.
-# Archive final versions can be installed, but downloading those releases are slow(er).
-RUN curl --location --remote-name https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz \
+# TeX Live is pinned to a specific release, installed from the frozen tlnet-final
+# tree in the CTAN historic archive. The rolling tlnet tree always serves the
+# *current* release, which silently upgrades the typesetting engine on every
+# rebuild and desynchronises TEXLIVE_VERSION below.
+#
+# Bumping TEXLIVE_VERSION is a deliberate engine upgrade: rebuild, then re-check
+# that main.pdf still fits on one page before relying on it.
+#
+# Both the installer and tlmgr must point at the same frozen tree. TeX Live
+# refuses to run an installer against a repository of a different year, and
+# tlmgr otherwise defaults back to the rolling tree.
+ARG TEXLIVE_VERSION=2025
+ARG TEXLIVE_REPO=https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/$TEXLIVE_VERSION/tlnet-final
+RUN curl --location --remote-name $TEXLIVE_REPO/install-tl-unx.tar.gz \
   && mkdir --parent /tmp/tlnet \
   && tar --strip-components 1 --directory /tmp/tlnet --extract --file install-tl-unx.tar.gz \
   && echo 'selected_scheme scheme-basic' >> /tmp/tlnet/texlive.profile \
-  && /tmp/tlnet/install-tl --profile=/tmp/tlnet/texlive.profile \
+  && /tmp/tlnet/install-tl --profile=/tmp/tlnet/texlive.profile --repository $TEXLIVE_REPO \
   && rm -rf install-tl-unx.tar.gz /tmp/tlnet
 # PATH, etc. must be set correctly according to the TeX Live version.
-ARG TEXLIVE_VERSION=2025
 ENV PATH=/usr/local/texlive/$TEXLIVE_VERSION/bin/x86_64-linux:$PATH
 ENV MANPATH=/usr/local/texlive/$TEXLIVE_VERSION/texmf-dist/doc/man
 ENV INFOPATH=/usr/local/texlive/$TEXLIVE_VERSION/texmf-dist/doc/info
-RUN tlmgr install \
+RUN tlmgr --repository $TEXLIVE_REPO install \
   academicons \
   arydshln \
   fontawesome5 \


### PR DESCRIPTION
Closes #68. Makes the `Dockerfile` safe to edit again, and fixes a name-spacing bug in the CV as a side effect.

## The problem

`install-tl` was downloaded from the rolling tlnet tree, which always serves the **current** release, while `ARG TEXLIVE_VERSION=2025` and `PATH=/usr/local/texlive/2025/...` were hardcoded. tlnet now serves TeX Live 2026, so a rebuild would install into `/usr/local/texlive/2026/`, leave `tlmgr` off `PATH`, and fail.

Because `build-and-push-image.yml` triggers on `paths: [Dockerfile]`, **any** edit — including a one-line comment — would have tripped it.

## The fix

Install from the frozen `tlnet-final` tree in the CTAN historic archive, so `ARG TEXLIVE_VERSION=2025` is true rather than aspirational.

Two changes were needed, not one:

- **The installer had to move too.** TeX Live refuses to run an installer against a repository of a different year, so pointing only `--repository` at the frozen tree still fails.
- **`tlmgr` needs its own `--repository`.** It otherwise defaults back to the rolling tree and fails identically, just later.

Also pinned `FROM ubuntu:latest` → `ubuntu:24.04` — an unpinned base is the same class of problem. 24.04 is what the currently published image was built from, confirmed by reading `/etc/os-release` out of it, so this pins to known-good rather than changing anything.

Dropped the `git` install. Its only justification was `# Needed for GitHub codespaces.`, and Codespaces went in 2fd8bdb (#66). Nothing in the build uses git — the footer version comes from `version.txt`. This was the cleanup blocked on this issue.

## Verification

The image was built locally with podman **before** any of this reached CI, then the CV was built with both images and diffed word by word.

```
published image   1 page, 43348 bytes
pinned image      1 page, 43351 bytes
```

## The layout is not identical — this was not expected

`tlnet-final` is the **end-of-2025** snapshot, while the published image was built mid-2025 from the rolling tree. So this is still an upgrade *within* TeX Live 2025: `latexmk` 4.86a → 4.87, plus a newer `moderncv`.

The visible effect is a fix. The published CV renders the name with a space too tight to register, so `pdftotext` extracts it as the single token `RóbertKohányi` — which is what a CV parser, or anyone copying the name out of the PDF, gets today. It now extracts as `Róbert` and `Kohányi`.

The contact block also moves 3.075pt right, from `532.674` to `535.748`, which is flush with the right text margin where it was previously short of it.

Every other glyph on the page is unmoved, and it is still one page. Reviewed before/after and adopted deliberately.

## Follow-up worth doing separately

Both `build.yml` and `build-podman.sh` still reference `:latest`. Even a *successful* rebuild therefore swaps the engine under the CV — which is how this issue became possible. Pinning those to an image digest would decouple "the image was rebuilt" from "my CV renders differently". Not done here; it needs the digest this PR's rebuild produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYrrbD4tMv7PddnixE3GPi
